### PR TITLE
Save the origin from the project meta object.

### DIFF
--- a/lib/sb2.js
+++ b/lib/sb2.js
@@ -238,6 +238,9 @@ module.exports = function (project, callback) {
     // Extensions
     meta.extensions = extensions(project);
 
+    // Metadata is only in sb3s so just fill in an empty object.
+    meta.meta = {};
+
     // Return all metadata
     return callback(null, meta);
 };

--- a/lib/sb3.js
+++ b/lib/sb3.js
@@ -125,6 +125,12 @@ const extensions = function (list) {
     };
 };
 
+const metadata = function (meta) {
+    return {
+        origin: meta.origin ? meta.origin : ''
+    };
+};
+
 module.exports = function (project, callback) {
     const meta = {
         scripts: scripts(project.targets),
@@ -136,7 +142,8 @@ module.exports = function (project, callback) {
         costumes: extract(project.targets, 'costumes', 'name', 'md5ext'),
         sprites: sprites(project.targets),
         blocks: blocks(project.targets),
-        extensions: extensions(project.extensions)
+        extensions: extensions(project.extensions),
+        meta: metadata(project.meta)
     };
 
     callback(null, meta);

--- a/test/fixtures/sb3/default.json
+++ b/test/fixtures/sb3/default.json
@@ -98,6 +98,7 @@
   "meta": {
     "semver": "3.0.0",
     "vm": "0.2.0-prerelease.20181217191056",
-    "agent": "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_14_1) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/70.0.3538.110 Safari/537.36"
+    "agent": "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_14_1) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/70.0.3538.110 Safari/537.36",
+    "origin": "test.scratch.mit.edu"
   }
 }

--- a/test/unit/sb2.js
+++ b/test/unit/sb2.js
@@ -69,6 +69,9 @@ test('defalt (object)', t => {
         t.equal(result.extensions.count, 0);
         t.deepEqual(result.extensions.id, []);
 
+        t.type(result.meta, 'object');
+        t.deepEqual(result.meta, {});
+
         t.end();
     });
 });

--- a/test/unit/sb3.js
+++ b/test/unit/sb3.js
@@ -75,6 +75,8 @@ test('defalt (object)', t => {
         t.equal(result.extensions.count, 0);
         t.deepEqual(result.extensions.id, []);
 
+        t.type(result.meta, 'object');
+        t.equal(result.meta.origin, 'test.scratch.mit.edu');
         t.end();
     });
 });
@@ -136,6 +138,9 @@ test('defalt (binary)', t => {
         t.type(result.extensions, 'object');
         t.equal(result.extensions.count, 0);
         t.deepEqual(result.extensions.id, []);
+
+        t.type(result.meta, 'object');
+        t.equal(result.meta.origin, '');
 
         t.end();
     });


### PR DESCRIPTION
- Part of the solution to https://github.com/LLK/scratch-search/issues/218
-  For sb2s, make it always empty.
