### PR TITLE
Fix the extraction of extension information

### DIFF
--- a/lib/sb2.js
+++ b/lib/sb2.js
@@ -188,7 +188,7 @@ const blocks = function (project) {
  */
 const extensions = function (project) {
     const result = {count: 0, id: []};
-    const ext = project.info.savedExtensions;
+    const ext = project.info?.savedExtensions;
 
     // Check to ensure project includes any extensions
     if (typeof ext === 'undefined') return result;

--- a/lib/sb3.js
+++ b/lib/sb3.js
@@ -156,10 +156,11 @@ const blocks = function (targets) {
 };
 
 const extensions = function (list) {
-    return {
-        count: (typeof list === 'object' ? list.length : 0),
-        id: (typeof list === 'object' ? list : [])
-    };
+    if (Array.isArray(list)) {
+        return {count: list.length, id: list};
+    }
+
+    return {count: 0, id: []};
 };
 
 const metadata = function (meta) {

--- a/test/fixtures/sb2/infoMissing.json
+++ b/test/fixtures/sb2/infoMissing.json
@@ -1,0 +1,8 @@
+{
+  "objName": "Stage",
+  "costumes": [],
+  "currentCostumeIndex": 0,
+  "penLayerMD5": "l.png",
+  "tempoBPM": 60,
+  "children": []
+}

--- a/test/fixtures/sb3/extensionsObject.json
+++ b/test/fixtures/sb3/extensionsObject.json
@@ -1,0 +1,8 @@
+{
+  "targets": [],
+  "monitors": [],
+  "extensions": {},
+  "meta": {
+      "semver": "3.0.0"
+  }
+}

--- a/test/unit/sb2.js
+++ b/test/unit/sb2.js
@@ -20,6 +20,10 @@ const invalidCostumes = fs.readFileSync(
     path.resolve(__dirname, '../fixtures/sb2/invalid-costumes.json')
 );
 
+const missingInfo = fs.readFileSync(
+    path.resolve(__dirname, '../fixtures/sb2/infoMissing.json')
+);
+
 test('default (object)', t => {
     analysis(defaultObject, (err, result) => {
         t.ok(typeof err === 'undefined' || err === null);
@@ -321,6 +325,14 @@ test('stage with invalid costumes', t => {
         t.same(result.backdrops.id, []);
         t.same(result.backdrops.hash, []);
 
+        t.end();
+    });
+});
+
+test('works with a project where the "info" field is missing', t => {
+    analysis(missingInfo, (err, result) => {
+        t.ok(typeof err === 'undefined' || err === null);
+        t.type(result, 'object');
         t.end();
     });
 });

--- a/test/unit/sb3.js
+++ b/test/unit/sb3.js
@@ -29,6 +29,10 @@ const missingVariableField = fs.readFileSync(
     path.resolve(__dirname, '../fixtures/sb3/missingVariableField.json')
 );
 
+const extensionsObject = fs.readFileSync(
+    path.resolve(__dirname, '../fixtures/sb3/extensionsObject.json')
+);
+
 test('default (object)', t => {
     analysis(defaultObject, (err, result) => {
         t.ok(typeof err === 'undefined' || err === null);
@@ -482,6 +486,18 @@ test('missing VARIABLE field in a block does not break the library', t => {
         t.ok(typeof err === 'undefined' || err === null);
         t.type(result, 'object');
 
+        t.end();
+    });
+});
+
+test('works with a project where "extensions" is an object', t => {
+    analysis(extensionsObject, (err, result) => {
+        t.ok(typeof err === 'undefined' || err === null);
+        t.type(result, 'object');
+
+        t.type(result.extensions, 'object');
+        t.equal(result.extensions.count, 0);
+        t.same(result.extensions.id, []);
         t.end();
     });
 });


### PR DESCRIPTION
### Proposed Changes
Fix the bugs that sometimes occur during the extraction of extensions. 

### Reason for Changes
The library:
- Returns unexpected results for some SB3 projects: if the `extensions` field in an SB3 project JSON is an object, then `extensions.count` in the analysis result is `undefined`.
- Fails with an unhandled error when the `info` field is missing from an SB2 project JSON.

`scratch-parser` doesn't enforce the presence or shape of the `extensions` field in the SB3 schema, or `info` in the SB2 schema, so `scratch-analysis` has to check these values itself.

### Test Coverage
- Unit tests.