### PR TITLE
[IPR-1939] fix: update scratch-parser

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -9,7 +9,7 @@
       "version": "2.4.1",
       "license": "BSD-3-Clause",
       "dependencies": {
-        "scratch-parser": "5.0.0",
+        "scratch-parser": "6.0.0",
         "scratch-sb1-converter": "2.0.50"
       },
       "devDependencies": {
@@ -9823,37 +9823,18 @@
       }
     },
     "node_modules/scratch-parser": {
-      "version": "5.0.0",
-      "resolved": "https://registry.npmjs.org/scratch-parser/-/scratch-parser-5.0.0.tgz",
-      "integrity": "sha512-7kjxoxivLgYYvmAJVLOOWnca4CigwuCpgjy9+6UuxOMgSZKO1xqIjxIADupabmh1ZLZZDVe45DBM/CQTdtVDkw==",
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/scratch-parser/-/scratch-parser-6.0.0.tgz",
+      "integrity": "sha512-LXcKxJIupqBtXSe2+SXkQxwdMWg4JCdZfoSdPYj1ZtV/UhejyUYju6ptYUrr98RsLFT5UyCmmUaev8gA1SNvhQ==",
+      "license": "AGPL-3.0-only",
       "dependencies": {
-        "ajv": "6.3.0",
-        "jszip": "3.1.5",
-        "pify": "4.0.1"
+        "ajv": "^6.3.0",
+        "jszip": "^3.1.5",
+        "pify": "^4.0.1"
       },
       "engines": {
         "node": ">=8.0"
       }
-    },
-    "node_modules/scratch-parser/node_modules/ajv": {
-      "version": "6.3.0",
-      "resolved": "https://registry.npmjs.org/ajv/-/ajv-6.3.0.tgz",
-      "integrity": "sha512-6TQywaGYtRub2fqHkSXfVANlhfja2nbF33wCCHnt3aQstOrtd9jsQGiRUTIOlkEqcxpzRd2akfnqvBBPmLxs8g==",
-      "dependencies": {
-        "fast-deep-equal": "^1.0.0",
-        "fast-json-stable-stringify": "^2.0.0",
-        "json-schema-traverse": "^0.3.0"
-      }
-    },
-    "node_modules/scratch-parser/node_modules/fast-deep-equal": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-1.1.0.tgz",
-      "integrity": "sha512-fueX787WZKCV0Is4/T2cyAdM4+x1S3MXXOAhavE1ys/W42SHAPacLTQhucja22QBYrfGw50M2sRiXPtTGv9Ymw=="
-    },
-    "node_modules/scratch-parser/node_modules/json-schema-traverse": {
-      "version": "0.3.1",
-      "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-0.3.1.tgz",
-      "integrity": "sha512-4JD/Ivzg7PoW8NzdrBSr3UFwC9mHgvI7Z6z3QGBsSHgKaRTUDmyZAAKJo2UbG1kUVfS9WS8bi36N49U1xw43DA=="
     },
     "node_modules/scratch-sb1-converter": {
       "version": "2.0.50",
@@ -24831,35 +24812,13 @@
       }
     },
     "scratch-parser": {
-      "version": "5.0.0",
-      "resolved": "https://registry.npmjs.org/scratch-parser/-/scratch-parser-5.0.0.tgz",
-      "integrity": "sha512-7kjxoxivLgYYvmAJVLOOWnca4CigwuCpgjy9+6UuxOMgSZKO1xqIjxIADupabmh1ZLZZDVe45DBM/CQTdtVDkw==",
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/scratch-parser/-/scratch-parser-6.0.0.tgz",
+      "integrity": "sha512-LXcKxJIupqBtXSe2+SXkQxwdMWg4JCdZfoSdPYj1ZtV/UhejyUYju6ptYUrr98RsLFT5UyCmmUaev8gA1SNvhQ==",
       "requires": {
-        "ajv": "6.3.0",
-        "jszip": "3.1.5",
-        "pify": "4.0.1"
-      },
-      "dependencies": {
-        "ajv": {
-          "version": "6.3.0",
-          "resolved": "https://registry.npmjs.org/ajv/-/ajv-6.3.0.tgz",
-          "integrity": "sha512-6TQywaGYtRub2fqHkSXfVANlhfja2nbF33wCCHnt3aQstOrtd9jsQGiRUTIOlkEqcxpzRd2akfnqvBBPmLxs8g==",
-          "requires": {
-            "fast-deep-equal": "^1.0.0",
-            "fast-json-stable-stringify": "^2.0.0",
-            "json-schema-traverse": "^0.3.0"
-          }
-        },
-        "fast-deep-equal": {
-          "version": "1.1.0",
-          "resolved": "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-1.1.0.tgz",
-          "integrity": "sha512-fueX787WZKCV0Is4/T2cyAdM4+x1S3MXXOAhavE1ys/W42SHAPacLTQhucja22QBYrfGw50M2sRiXPtTGv9Ymw=="
-        },
-        "json-schema-traverse": {
-          "version": "0.3.1",
-          "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-0.3.1.tgz",
-          "integrity": "sha512-4JD/Ivzg7PoW8NzdrBSr3UFwC9mHgvI7Z6z3QGBsSHgKaRTUDmyZAAKJo2UbG1kUVfS9WS8bi36N49U1xw43DA=="
-        }
+        "ajv": "^6.3.0",
+        "jszip": "^3.1.5",
+        "pify": "^4.0.1"
       }
     },
     "scratch-sb1-converter": {

--- a/package.json
+++ b/package.json
@@ -16,7 +16,7 @@
   "author": "Scratch Foundation",
   "license": "BSD-3-Clause",
   "dependencies": {
-    "scratch-parser": "5.0.0",
+    "scratch-parser": "6.0.0",
     "scratch-sb1-converter": "2.0.50"
   },
   "devDependencies": {


### PR DESCRIPTION
The purpose of this PR is to update the scratch-parser to its latest version. In it a problem with parsing project-files is fixed. The problem itself consists of wrongly regex-replacing backslashes(\b) in json files.